### PR TITLE
Updated Eggmoves inheriting to Gen 6

### DIFF
--- a/P3D/Screens/Pokemon/Daycare.vb
+++ b/P3D/Screens/Pokemon/Daycare.vb
@@ -82,15 +82,16 @@
                 male = 1
             End If
             If male > -1 Then
-                Dim cParent As Pokemon = Nothing
-                Select Case male
-                    Case 0
-                        cParent = parent1
-                    Case 1
-                        cParent = parent2
-                End Select
                 For Each BreedMove As Integer In p.EggMoves
-                    For Each m1 As BattleSystem.Attack In cParent.Attacks
+                    For Each m1 As BattleSystem.Attack In parent1.Attacks
+                        If m1.ID = BreedMove Then
+                            GameJolt.Emblem.AchieveEmblem("eggsplosion")
+
+                            Dim newAttack As BattleSystem.Attack = BattleSystem.Attack.GetAttackByID(m1.ID)
+                            EggMoves.Add(newAttack)
+                        End If
+                    Next
+                    For Each m1 As BattleSystem.Attack In parent2.Attacks
                         If m1.ID = BreedMove Then
                             GameJolt.Emblem.AchieveEmblem("eggsplosion")
 


### PR DESCRIPTION
Since Gen VI Egg moves can be inherited from both parents.
https://bulbapedia.bulbagarden.net/wiki/Egg_Move

So the new behaviour is now like this:
Parent1
![p1](https://user-images.githubusercontent.com/5148555/52869962-1e29b680-3147-11e9-8f2a-96daa492f763.png)
+ Parent2
![p2](https://user-images.githubusercontent.com/5148555/52869988-25e95b00-3147-11e9-9cf4-03fcdff139e9.png)
=Result
![r](https://user-images.githubusercontent.com/5148555/52869998-2a157880-3147-11e9-8a07-8f5fdb06633f.png)


