### PR TITLE
PauseScreen Crash fix

### DIFF
--- a/P3D/Screens/MainMenu/PauseScreen.vb
+++ b/P3D/Screens/MainMenu/PauseScreen.vb
@@ -78,10 +78,12 @@
 
         Screen.TextBox.reDelay = 0.0F
 
-        If Me.menuIndex = 0 Then
-            UpdateMain()
-        Else
-            UpdateQuit()
+        If Core.GameInstance.IsActive = True Then
+            If Me.menuIndex = 0 Then
+                UpdateMain()
+            Else
+                UpdateQuit()
+            End If
         End If
     End Sub
 


### PR DESCRIPTION
Fixed crash that occurs when exiting to the main menu through the pause screen while the game window is minimized or not active in general.