### PR TITLE
Infinitely Moving OverworldPokemon Fix

### DIFF
--- a/P3D/Entites/Other/OverworldPokemon.vb
+++ b/P3D/Entites/Other/OverworldPokemon.vb
@@ -159,7 +159,7 @@ Public Class OverworldPokemon
     End Sub
 
     Private Sub ChangePosition()
-        If Screen.Camera.IsMoving() = True Then
+        If Screen.Camera.IsMoving() = True And Core.CurrentScreen.Identification = Screen.Identifications.OverworldScreen Then
             If CInt(Me.Position.X) <> CInt(Screen.Camera.Position.X) Or CInt(Me.Position.Z) <> CInt(Screen.Camera.Position.Z) Then
                 Me.Position += GetMove()
                 Me.AnimationDelayLenght = 1.1F


### PR DESCRIPTION
Fixed OverworldPokemon from continuing to walk infinitely when pausing the game, opening a chat window or while the current screen is any other screen than OverworldScreen