### PR TITLE
Fix the overworld rendering when inventory is opened.

### DIFF
--- a/P3D/Screens/Inventory/NewInventoryScreen.vb
+++ b/P3D/Screens/Inventory/NewInventoryScreen.vb
@@ -139,7 +139,7 @@ Public Class NewInventoryScreen
     Public Sub New(ByVal currentScreen As Screen, ByVal AllowedPages As Integer(), ByVal StartPageIndex As Integer, ByVal DoStuff As DoStuff, Optional ByVal AllowedItems As List(Of String) = Nothing, Optional ByVal DoReturnItem As Boolean = False)
 
         SelectedItem = "-1"
-        _preScreenTarget = New RenderTarget2D(GraphicsDevice, windowSize.Width, windowSize.Height)
+        _preScreenTarget = New RenderTarget2D(GraphicsDevice, windowSize.Width, windowSize.Height, False, SurfaceFormat.Color, DepthFormat.Depth24Stencil8)
         _blur = New Resources.Blur.BlurHandler(windowSize.Width, windowSize.Height)
 
         If AllowedPages.Contains(StartPageIndex) = False Then


### PR DESCRIPTION
Before
![2025-02-21_22 23 52](https://github.com/user-attachments/assets/e116891b-8fc9-419d-8037-14d37f789c21)

After
![2025-02-21_22 22 36](https://github.com/user-attachments/assets/aec26366-701d-458c-a290-e5d656c3a88e)